### PR TITLE
Fixed Tracker, Previous version had the rss in the wrong order.

### DIFF
--- a/Acid-Lounge.tracker
+++ b/Acid-Lounge.tracker
@@ -74,12 +74,13 @@
 				<!--http://www.acid-lounge.org.uk/rssdownload.php?passkey=XXXXXXXXXX&uid=XXXXX&tid=XXXX-->
 				<string value="http://"/>
 				<var name="$baseUrl"/>
-				<string value="rssdownload.php?tid="/>
-				<var name="$torrentId"/>
+				<string value="rssdownload.php?"/>
 				<string value="&amp;passkey="/>
 				<var name="passkey"/>
 				<string value="&amp;uid="/>
 				<var name="uid"/>
+				<string value="&amp;tid="/>
+				<var name="$torrentId"/>
 			</var>
 		</linematched>
 		<ignore>


### PR DESCRIPTION
The rss url previously had the uid, torrentid and passkey in the wrong order, Causing an error collecting a torrent from this tracker.
