### PR TITLE
Update server name for DK-Scene

### DIFF
--- a/DK-Scene.tracker
+++ b/DK-Scene.tracker
@@ -37,7 +37,7 @@
 	<servers>
 		<server
 			network="DK-Scene.org"
-			serverNames="DK-Scene.org"
+			serverNames="irc.DK-Scene.org"
 			channelNames="#announce"
 			announcerNames="DK-Scene"
 		/>


### PR DESCRIPTION
Updated server name for DK-Scene as irc.dk-scene.org is now required to join the IRC server