### PR TITLE
Add releaseGroup support for NextGen

### DIFF
--- a/NextGen.tracker
+++ b/NextGen.tracker
@@ -58,6 +58,13 @@
 				</extract>
 			</linepatterns>
 			<linematched>
+				<!-- Extract releaseGroup from torrent name -->
+				<extract srcvar="torrentName" optional="true">
+					<regex value="(?:.*?[\._\s\-])+.*?-(.*?)(?:\..*)?$"/>
+					<vars>
+						<var name="releaseGroup"/>
+					</vars>
+				</extract>
 				<var name="torrentUrl">
 					<string value="http://"/>
 					<var name="$baseUrl"/>


### PR DESCRIPTION
Updating the NextGen tracker to include the releasegroup match option included in the new autodl-irssi rutorrent plugin version.
It's a small non-intrusive update.