### PR TITLE
Update domain name for NextGen tracker

### DIFF
--- a/NextGen.tracker
+++ b/NextGen.tracker
@@ -27,17 +27,17 @@
 	type="ng"
 	shortName="NG"
 	longName="NextGen"
-	siteName="nxtgn.info">
+	siteName="nxtgn.biz">
 
 	<settings>
-		<description text="Go to http://nxtgn.info/getrss.php to get the RSS feed link. Paste it (Ctrl+V) into the text box below to automatically extract passkey."/>
+		<description text="Go to http://nxtgn.biz/getrss.php to get the RSS feed link. Paste it (Ctrl+V) into the text box below to automatically extract passkey."/>
 		<passkey tooltiptext="The passkey in your NextGen RSS feed link."/>
 	</settings>
 
 	<servers>
 		<server
 			network="NExTGen"
-			serverNames="irc.nxtgn.info"
+			serverNames="irc.nxtgn.biz"
 			channelNames="#Announce"
 			announcerNames="James"
 			/>
@@ -46,7 +46,7 @@
 	<parseinfo>
 			<linepatterns>
 				<extract>
-					<!--~ [ DSB ] ~ [ Game.of.Thrones.S03D01.Retail.DKSubs.NTSC.DVDR-DSB ] ~ [ 4.414 GB ] ~ [ http://nxtgn.info/details.php?id=309699 ] ~-->
+					<!--~ [ DSB ] ~ [ Game.of.Thrones.S03D01.Retail.DKSubs.NTSC.DVDR-DSB ] ~ [ 4.414 GB ] ~ [ http://nxtgn.biz/details.php?id=309699 ] ~-->
 					<regex value="^~\s*\[\s([^\]]*)\]\s~\s\[\s([^\]]*)\]\s~\s\[\s([^\]]*)\]\s~\s\[ https?\:\/\/([^\/]+\/).*[&amp;\?]id=(\d+)\ ]"/>
 					<vars>
 						<var name="category"/>


### PR DESCRIPTION
Updated the domain name for NextGen tracker as stricter rules have forced a domain change - moving from .info to .biz. Hopefully this will be the end of domain switching.