### PR TITLE
https causing issues

### DIFF
--- a/GFTracker.tracker
+++ b/GFTracker.tracker
@@ -60,7 +60,7 @@
 		</linepatterns>
 		<linematched>
 			<var name="torrentUrl">
-				<string value="https://"/>
+				<string value="http://"/>
 				<var name="$baseUrl"/>
 				<string value="download.php?torrent="/>
 				<var name="$torrentId"/>


### PR DESCRIPTION
Update all pearls and openssl and it still doesn't work with https. My seedbox provider uses Debian though. Can we use http?