### PR TITLE
Overhaul HoundDawgs.tracker

### DIFF
--- a/HoundDawgs.tracker
+++ b/HoundDawgs.tracker
@@ -20,7 +20,7 @@
    - the Initial Developer. All Rights Reserved.
    -
    - Contributor(s):
-   -
+   - THEGURUDK
    - ***** END LICENSE BLOCK ***** -->
 
 <trackerinfo
@@ -47,12 +47,27 @@
 	<parseinfo>
 		<linepatterns>
 			<extract>
-					<!--[Film HD] To The Wonder 2012 Retail DKSubs 720p BluRay x264-TREATS - http://www.hounddawgs.org/torrents.php?id=1465 - 4.37 GB-->
-					<regex value="^\[([^\]]*)](.*)-(.*)\s-\s+https?\:\/\/([^\/]+).*[&amp;\?]id=(\d+)\s*-(.*)"/>
+					<!--[Musik] The_Weeknd-Beauty_Behind_The_Madness-2015-H3X (Scene) [CD V0] - https://hounddawgs.org/torrents.php?id=35459 - 116.03 MiB-->
+					<!--[Musik] Riverside-Love_Fear_And_The_Time_Machine-(Limited_Edition)-2CD-2015-gnvr - https://hounddawgs.org/torrents.php?id=35442 - 152.52 MiB-->
+					<!--[Musik] [FreeLeech] Riverside-Love_Fear_And_The_Time_Machine-(Limited_Edition)-2CD-2015-gnvr - https://hounddawgs.org/torrents.php?id=35442 - 152.52 MiB-->
+					<regex value="^\[(Musik)\] (?:\[(FreeLeech)\] |)(\S+)(?: .+?|) - https?\:\/\/(?:www\.|)([^\/]+)[^=]*=(\d+) -(.*)"/>
 				<vars>
 					<var name="category"/>
+					<var name="$freeleech"/>
 					<var name="torrentName"/>
-					<var name="uploader"/>
+					<var name="$baseUrl"/>
+					<var name="$torrentId"/>
+					<var name="torrentSize"/>
+				</vars>
+			</extract>
+			<extract>
+					<!--[Film HD] To The Wonder 2012 Retail DKSubs 720p BluRay x264-TREATS - http://www.hounddawgs.org/torrents.php?id=1465 - 4.37 GB-->
+					<!--[Film HD] [FreeLeech] To The Wonder 2012 Retail DKSubs 720p BluRay x264-TREATS - http://www.hounddawgs.org/torrents.php?id=1465 - 4.37 GB-->
+					<regex value="^\[((?!.*Musik).+?)\] (?:\[(FreeLeech)\] |)(.*) - https?\:\/\/(?:www\.|)([^\/]+)[^=]*=(\d+) - (.*)"/>
+				<vars>
+					<var name="category"/>
+					<var name="$freeleech"/>
+					<var name="torrentName"/>
 					<var name="$baseUrl"/>
 					<var name="$torrentId"/>
 					<var name="torrentSize"/>
@@ -60,6 +75,23 @@
 			</extract>
 		</linepatterns>
 		<linematched>
+			
+			<setregex srcvar="$freeleech" regex="FreeLeech" varName="freeleech" newValue="true"/>
+		
+			<extract srcvar="torrentName" optional="true">
+				<regex value="(?:.*?[\._\s])+.*?-(.*?)(?:\..*)?$"/>
+				<vars>
+					<var name="releaseGroup"/>
+				</vars>
+			</extract>
+			
+			<extract srcvar="torrentName" optional="true">
+				<regex value="(?:.*?[\._\s])+.*?-(.*?)(?:\..*)?$"/>
+				<vars>
+					<var name="uploader"/>
+				</vars>
+			</extract>
+			
 			<var name="torrentUrl">
 				<string value="http://"/>
 				<var name="$baseUrl"/>
@@ -72,7 +104,6 @@
 			</var>
 		</linematched>
 		<ignore>
-			<regex value="torrents\.php\?id=\d+" expected="false"/>
 		</ignore>
 	</parseinfo>
 </trackerinfo>


### PR DESCRIPTION
* Torrentname has now been fixed to include the entire torrentname (releasegroup was omitted, and captured in its own capturegroup to match uploader)
* Added support for matching releasegroup (and uploader for backwards compatibility after a community vote, too many issues if not included I assume)
* Split music from the main string to cope with weird torrentnames - thereby fixing issues with releasegroup matching
* Added support for FreeLeech option

I tried to keep the RegEx as readable as possible. Some might argue that it could be shortened but from testing it revealed that shortening it would not decrease the amount of steps needed for a match and only led to the RegEx to be harder to understand.
Some might argue that I could use the (scene) tag in some of the music uploads but they far between and would only result in more errors.