### PR TITLE
Update AnimeBytes freeleech announce

### DIFF
--- a/AnimeBytes.tracker
+++ b/AnimeBytes.tracker
@@ -92,7 +92,7 @@
 				<setvarif varName="media" regex="^(?:CD|DVD|Vinyl|Soundboard|SACD|DAT|Cassette|WEB)$"/>
 				<setvarif varName="resolution" regex="^(?:SD|Standard?Def.*|480i|480p|576p|720p|810p|1080p|1080i)$"/>
 				<setvarif varName="$episodeString" regex="^Episode \d+$"/>
-				<setvarif varName="freeleech" value="Freeleech!" newValue="true"/>
+				<setvarif varName="freeleech" value="Freeleech" newValue="true"/>
 
 				<!--Ignored-->
 				<regex value=""/>


### PR DESCRIPTION
AnimeBytes now announces freeleech using "Freeleech" instead of "Freeleech!"
There is no longer a exclamation mark.

For example:
`16:50 <@Satsuki> JoJo's Bizarre Adventure: Diamond Is Unbreakable - TV
                 Series  [2016] :: Web / MKV / h264 10-bit / 720p / AAC /
                 Softsubs (Some-Stuffs) / Episode 19 / Freeleech ||
                 https://animebytes.tv/torrents.php?id=27874&torrentid=250709
                 || adventure, shounen, manga, action, airing || Uploaded by:
                 Isla`