### PR TITLE
Update ScienceHD network name.

### DIFF
--- a/ScienceHD.tracker
+++ b/ScienceHD.tracker
@@ -37,7 +37,7 @@
 
 	<servers>
 		<server
-			network="ScienceHD"
+			network="ForPirates"
 			serverNames="irc.sciencehd.me"
 			channelNames="#SciHD-Announce"
 			announcerNames="Xen"


### PR DESCRIPTION
ScienceHD changed their network name and the changes reflect the change.