### PR TITLE
Update AnimeBytes IRC domains

### DIFF
--- a/AnimeBytes.tracker
+++ b/AnimeBytes.tracker
@@ -38,7 +38,7 @@
 	<servers>
 		<server
 			network="AnimeBytes"
-			serverNames="irc.animebytes.tv,keiko.animebytes.tv,irc.animebyt.es"
+			serverNames="irc.animebytes.tv"
 			channelNames="#announce"
 			announcerNames="Satsuki"
 		/>


### PR DESCRIPTION
Use only official domain name that supports SSL and remove old unused domain names that are no longer in use.
