### PR TITLE
Follow 302/301 links for AnimeBytes

### DIFF
--- a/AnimeBytes.tracker
+++ b/AnimeBytes.tracker
@@ -27,7 +27,8 @@
 	type="ab"
 	shortName="AB"
 	longName="AnimeBytes"
-	siteName="animebytes.tv">
+	siteName="animebytes.tv"
+	follow302links="true">
 
 	<settings>
 		<gazelle_description/>


### PR DESCRIPTION
Due to some codebase changes, AnimeBytes is now handling old torrent download links as 301 redirect to new location (/torrent/{id:[0-9]+}/download/{passKey:[a-zA-Z0-9]{32}} - see also https://github.com/autodl-community/autodl-trackers/pull/166). 

While another PR was opened to change download link generated by autodl I think adding this option will ensure that should the link change again it will not cause problems for users again. For a note, AnimeBytes handles invalid torrent download links by returning 403 if {passKey} is missing or 404 if user or torrent is missing. Other requests to private-facing part of site without authentication will see 303 returned by server.
