### PR TITLE
Pixel-HD: fix releaseGroup variable

### DIFF
--- a/Pixel-HD.tracker
+++ b/Pixel-HD.tracker
@@ -63,7 +63,7 @@
 				<regex value="^Uploader:(.*)\| Release Group:(.*)\| Format:(.*)$"/>
 				<vars>
 					<var name="uploader"/>
-					<var name="$releaseGroup"/>
+					<var name="releaseGroup"/>
 					<var name="category"/>
 				</vars>
 			</extract>


### PR DESCRIPTION
This should make it work with the match-release-groups filter