### PR TITLE
PTH rebranded as RED

### DIFF
--- a/Redacted.tracker
+++ b/Redacted.tracker
@@ -24,10 +24,10 @@
    - ***** END LICENSE BLOCK ***** -->
 
 <trackerinfo
-	type="pth"
-	shortName="PTH"
-	longName="PassTheHeadphones"
-	siteName="passtheheadphones.me">
+	type="red"
+	shortName="RED"
+	longName="Redacted"
+	siteName="redacted.ch">
 
 	<settings>
 		<gazelle_description/>
@@ -37,9 +37,9 @@
 
 	<servers>
 		<server
-			network="PassTheHeadphones"
-			serverNames="irc.passtheheadphones.me"
-			channelNames="#pth-announce"
+			network="Scratch Network"
+			serverNames="irc.scratch-network.net"
+			channelNames="#red-announce"
 			announcerNames="Drone"
 			/>
 	</servers>


### PR DESCRIPTION
**Please read the contributing guidelines linked above before opening a pull request.**
PassTheHeadphones rebranded as Redacted, so I moved PassTheHeadphones.tracker to Redacted.tracker and made changes.