### PR TITLE
Update Apollo.tracker

### DIFF
--- a/Apollo.tracker
+++ b/Apollo.tracker
@@ -49,7 +49,7 @@
 	<parseinfo>
 		<linepatterns>
 			<extract>
-				<regex value="TORRENT: (.*)-(.*).*\s*https?\:\/\/([^\/]+\/).*[&amp;\?]id=(\d+)"/>
+				<regex value="TORRENT: (.*)-.*.*\s*https?\:\/\/([^\/]+\/).*[&amp;\?]id=(\d+)"/>
 				<vars>
 					<var name="torrentName"/>
 					<var name="$baseUrl"/>


### PR DESCRIPTION
Only 3 vars where defined to capture, but 4 captures were defined in the regex. 
This led to a "invalid extractInfo.vars.length" error.
Removed the unneeded capture in the regex.
