### PR TITLE
Update PixelHD to support genre tags

### DIFF
--- a/Pixel-HD.tracker
+++ b/Pixel-HD.tracker
@@ -60,15 +60,18 @@
 				</vars>
 			</extract>
 			<extract>
-				<regex value="^Uploader:(.*)\| Release Group:(.*)\| Format:(.*)$"/>
+				<regex value="^Uploader:(.*)\| Release Group:(.*)\| Format:(.*)\| Genre\(s\):(.*)$"/>
 				<vars>
 					<var name="uploader"/>
 					<var name="releaseGroup"/>
 					<var name="category"/>
+					<var name="tags"/>
 				</vars>
 			</extract>
 		</multilinepatterns>
 		<linematched>
+			<!-- Just in case of seperators -->
+			<varreplace name="tags" srcvar="tags" regex="[._]" replace=" "/>
 			<var name="torrentUrl">
 				<string value="http://"/>
 				<var name="$baseUrl"/>


### PR DESCRIPTION
As in title, Pixel-HD now adds Genre tags to the announces, this will support that.