### PR TITLE
Add release group and torrent name filters to AnimeBytes

### DIFF
--- a/AnimeBytes.tracker
+++ b/AnimeBytes.tracker
@@ -102,8 +102,10 @@
 			</extracttags>
 
 			<extract srcvar="torrentName" optional="true">
-				<regex value=".*\[(.*)\]"/>
+				<regex value="^(.+)\s-\s(.+)\s\[(\d{4})\]"/>
 				<vars>
+					<var name="name1"/>
+					<var name="name2"/>
 					<var name="year"/>
 				</vars>
 			</extract>

--- a/AnimeBytes.tracker
+++ b/AnimeBytes.tracker
@@ -93,6 +93,7 @@
 				<setvarif varName="bitrate" regex="^(?:vbr|aps|apx|v\d|\d{2,4}|\d+\.\d+|q\d+\.[\dx]+|Other)?(?:\s*kbps|\s*kbits?|\s*k)?(?:\s*\(?(?:vbr|cbr)\)?)?$"/>
 				<setvarif varName="media" regex="^(?:CD|DVD|Vinyl|Soundboard|SACD|DAT|Cassette|WEB)$"/>
 				<setvarif varName="resolution" regex="^(?:SD|Standard?Def.*|480i|480p|576p|720p|810p|1080p|1080i)$"/>
+				<setvarif varName="$releaseGroupString" regex="^(?:RAW|Softsubs|Hardsubs)?\s\(.+\)$"/>
 				<setvarif varName="$episodeString" regex="^Episode \d+$"/>
 				<setvarif varName="freeleech" value="Freeleech" newValue="true"/>
 
@@ -115,6 +116,13 @@
 				<string value="/download/"/>
 				<var name="passkey"/>
 			</var>
+
+			<extract srcvar="$releaseGroupString" optional="true">
+				<regex value="(?:RAW|Softsubs|Hardsubs)\s\((.+)\)"/>
+				<vars>
+					<var name="releaseGroup"/>
+				</vars>
+			</extract>
 
 			<extract srcvar="$episodeString" optional="true">
 				<regex value="Episode (\d+)"/>


### PR DESCRIPTION
Added custom release group filter since the built-in one doesn't work for AB. Also added torrent name filtering since it wasn't being captured.