### PR TITLE
Update NorBits regex for HTTPS URL

### DIFF
--- a/trackers/NorBits.tracker
+++ b/trackers/NorBits.tracker
@@ -46,7 +46,7 @@
 	<parseinfo>
 		<linepatterns>
 			<extract>
-				<regex value="Ny torrent: (.*) :: Kategori: (.*) :: Scene: (.*) :: St[&#248;]rrelse: (.*) :: http?\:\/\/([^\/]+\/).*[\?]id=(\d+)"/>
+				<regex value="Ny torrent: (.*) :: Kategori: (.*) :: Scene: (.*) :: St[&#248;]rrelse: (.*) :: https?\:\/\/([^\/]+\/).*[\?]id=(\d+)"/>
 				<vars>
 					<var name="torrentName"/>
 					<var name="category"/>


### PR DESCRIPTION
NorBits announce messages changed to HTTPS a few weeks ago, causing the regex to stop matching.