### PR TITLE
Fix download URLs in HD-Torrents & HD-Space

### DIFF
--- a/trackers/HD-Space.tracker
+++ b/trackers/HD-Space.tracker
@@ -63,7 +63,7 @@
 			<var name="torrentUrl">
 				<string value="https://"/>
 				<var name="$baseUrl"/>
-				<string value="/download.php?id="/>
+				<string value="download.php?id="/>
 				<var name="$torrentId"/>
 				<string value="&amp;f="/>
 				<varenc name="torrentName"/>

--- a/trackers/HD-Torrents.tracker
+++ b/trackers/HD-Torrents.tracker
@@ -62,7 +62,7 @@
 			<var name="torrentUrl">
 				<string value="https://"/>
 				<var name="$baseUrl"/>
-				<string value="/download.php?id="/>
+				<string value="download.php?id="/>
 				<var name="$torrentId"/>
 				<string value="&amp;f="/>
 				<varenc name="torrentName"/>


### PR DESCRIPTION
The URL generated previously was incorrect:

`https://hd-torrents.org//download...`

and
`https://hd-space.org//download...`

This is not the valid url, it should be like:

`https://hd-torrents.org/download...`

Chrome and Rtorrent know how to ignore the extra slash that was being added before however, other parsers (like Sonarr/Radarr using push release API) won't be able to use that URL and will return an error