### PR TITLE
Add Millie to BeyondHD announcerNames

### DIFF
--- a/trackers/BeyondHD.tracker
+++ b/trackers/BeyondHD.tracker
@@ -41,7 +41,7 @@
 			network="BeyondHD-IRC"
 			serverNames="irc.beyond-hd.me"
 			channelNames="#bhd_announce"
-			announcerNames="Willie"
+			announcerNames="Willie,Millie"
 			/>
 	</servers>
 


### PR DESCRIPTION
Recently BeyondHD required invites for bots to #bhd_announce, done by Millie. This lets functionality for approving invites in trackarr work correctly.