### PR TITLE
nCore: update to new domain and irc

### DIFF
--- a/trackers/nCore.tracker
+++ b/trackers/nCore.tracker
@@ -25,9 +25,9 @@
 
 <trackerinfo
 	type="nc"
-	shortName="nc"
+	shortName="nC"
 	longName="nCore"
-	siteName="ncore.cc">
+	siteName="ncore.pro">
 
 	<settings>
 		<description text="Check a torrent download link. key='value' is your passkey."/>
@@ -36,8 +36,8 @@
 
 	<servers>
 		<server
-			network="iRCLiNE"
-			serverNames="irc.ircline.org"
+			network="P2P-NET"
+			serverNames="irc.p2p-network.net"
 			channelNames="#ncore-bot"
 			announcerNames="nCore"
 			/>
@@ -46,8 +46,8 @@
 	<parseinfo>
 		<linepatterns>
 			<extract>
-				<!--[NEW TORRENT in xvidser_hun] The.Scooby-Doo.Show.S02.WEB-DL.HUN.ENG.x264-DenZo > 2.33 GB in 10F > https://ncore.cc/torrents.php?action=details&id=1843212-->
-				<regex value="\[NEW TORRENT in (.*)\] (.*) > (.*) in .* > (https?://ncore.cc.*action=).*id=(.*)"/>
+				<!--[NEW TORRENT in hdser_hun] Sherlock.S01-S04.COMPLETE.1080p.BluRay.DD5.1.x264.HUN.ENG-pcroland > 227.97 GiB in 46F > https://ncore.pro/torrents.php?action=details&id=3119161-->
+				<regex value="\[NEW TORRENT in (.*)\] (.*) > (.*) in .* > (https?://ncore.pro.*action=).*id=(.*)"/>
 				<vars>
 					<var name="category"/>
 					<var name="torrentName"/>


### PR DESCRIPTION
The site moved to a new domain (previos pull request from someone else) but then the announcer was also moved from iRCLiNE to P2P-NET. This commit also fixes that.