### PR TITLE
Update NBL announcer name to Muffit

### DIFF
--- a/trackers/Nebulance.tracker
+++ b/trackers/Nebulance.tracker
@@ -42,7 +42,7 @@
 			network="Nebulance"
 			serverNames="irc.nebulance.cc"
 			channelNames="#nbl-announce"
-			announcerNames="DRADIS"
+			announcerNames="Muffit"
 			/>
 	</servers>
 


### PR DESCRIPTION
Title says it all; we're merging bots, so the announcer is no longer DRADIS but Muffit.